### PR TITLE
Pinning the indicator installed version

### DIFF
--- a/configure_indicator.py
+++ b/configure_indicator.py
@@ -24,7 +24,8 @@ if not os.path.exists(AUTOSTART_DIR):
 
 shutil.copy(DESKTOP_PATH, AUTOSTART_PATH)
 
-exec(open('/usr/lib/indicator-sysmonitor/sensors.py').read())
+exec(open('/usr/share/indicator-sysmonitor/sysmonitor_common/sensors.py').read())
+
 
 mgr = SensorManager()
 mgr.update_regex()

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
-sudo apt-get install -y jq python3-psutil curl git gir1.2-appindicator3-0.1
+sudo apt-get install -y jq python3-psutil curl git gir1.2-appindicator3-0.1 meson ninja-build
+
 git clone https://github.com/fossfreedom/indicator-sysmonitor.git
 cd indicator-sysmonitor
-sudo make install
-cd ../
+git reset --hard cc5d095 # version the locindicator was tested against
+
+# Building the appindicator according to its docs
+mkdir build
+cd build
+meson setup --prefix=/usr
+sudo meson install
+
+# Cleaning up
+cd ../../
 rm -rf ./indicator-sysmonitor


### PR DESCRIPTION
The indicator dependency has updated the way it should be built. Making changes to pin to a specific dependency version.